### PR TITLE
Cleanup of the *.service files at generator; Support to re-write conserver and systemd configuration files when adding or removing an IOC

### DIFF
--- a/procServUtils/conf.py
+++ b/procServUtils/conf.py
@@ -8,8 +8,6 @@ try:
 except ImportError:
     from configparser import ConfigParser
 
-conserver_conf = '/etc/conserver/procs.cf'
-
 def getgendir(user=False):
     if user:
         return os.path.expanduser('~/.config/procServ.d')

--- a/procServUtils/conf.py
+++ b/procServUtils/conf.py
@@ -8,6 +8,8 @@ try:
 except ImportError:
     from configparser import ConfigParser
 
+conserver_conf = '/etc/conserver/procs.cf'
+
 def getgendir(user=False):
     if user:
         return os.path.expanduser('~/.config/procServ.d')

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -198,9 +198,9 @@ chdir = %(chdir)s
         args.out = conserver_conf
         writeprocs(conf, args)
 
-    # Check if should to re-write System-D service files
+    # Check if should to re-write systemd service files
     if args.writesysd:
-        _log.info('Trying to update System-D service files...')
+        _log.info('Trying to update systemd service files...')
         genrun(outdir=args.outsysd, user=args.user)
 
     # Daemon reloading
@@ -266,9 +266,9 @@ def delproc(conf, args):
         args.out = conserver_conf
         writeprocs(conf, args)
 
-    # Check if should to re-write System-D service files
+    # Check if should to re-write systemd service files
     if args.writesysd:
-        _log.info('Trying to update System-D service files...')
+        _log.info('Trying to update systemd service files...')
         genrun(outdir=args.outsysd, user=args.user)
 
     # Daemon reloading
@@ -353,7 +353,7 @@ def getargs():
                     help='Automatically update Conserver configuration')
     S.add_argument('-D', '--outsysd', default=systemd_dir)
     S.add_argument('-d', '--writesysd', action='store_true', default=True,
-                    help='Create System-D service files')
+                    help='Create systemd service files')
     S.add_argument('-R', '--reload', action='store_true', default=False,
                     help='Restart conserver-server')
     S.add_argument('--command', help='Command script or executable, without path (chdir is added later)')
@@ -367,7 +367,7 @@ def getargs():
                     help='Automatically update Conserver configuration')
     S.add_argument('-D', '--outsysd', default=systemd_dir)
     S.add_argument('-d', '--writesysd', action='store_true', default=True,
-                    help='Create System-D service files')
+                    help='Create systemd service files')
     S.add_argument('-R', '--reload', action='store_true', default=False,
                     help='Restart conserver-server')
     S.add_argument('name', help='Instance name')

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -7,6 +7,7 @@ import pwd, grp
 import subprocess as SP
 
 from .conf import getconf, getrundir, getgendir
+from .generator import run as genrun
 
 try:
     import shlex
@@ -19,7 +20,12 @@ _levels = [
     logging.DEBUG,
 ]
 
-systemctl = '/bin/systemctl'
+# -----------------------------------------------------------------------------
+# Default parameters
+# -----------------------------------------------------------------------------
+systemctl       = '/bin/systemctl'
+conserver_conf  = '/etc/conserver/procs.cf'
+systemd_dir     = '/etc/systemd/system'
 
 def status(conf, args, fp=None):
     rundir=getrundir(user=args.user)
@@ -32,7 +38,7 @@ def status(conf, args, fp=None):
 
         pid = None
         ports = []
-        infoname = os.path.join(rundir, 'procserv-%s'%name, 'info')
+        infoname = os.path.join(rundir, 'ioc@%s'%name, 'info')
         try:
             with open(infoname) as F:
                 _log.debug('Read %s', F.name)
@@ -134,7 +140,7 @@ def addproc(conf, args):
         if args.site == 'ess-e3':
             args.chdir = os.path.join(site_conf[args.site]['base_dir'], args.name)
             args.command = 'st.{}.cmd'.format(args.name)
-            port_dir = 'procserv-{}'.format(args.name)
+            port_dir = 'ioc@{}'.format(args.name)
             args.port = 'unix:{}'.format(os.path.join(
                 getrundir(), port_dir, 'control'))
             try:
@@ -174,17 +180,36 @@ chdir = %(chdir)s
 
     os.rename(cfile+'.tmp', cfile)
 
+    # Check if should to re-write Conserver coniguration file
+    if args.writeconf:
+        _log.info('Trying to update conserver configuration...')
+        # Updating conserver config file due the previous procedures
+        conf = getconf(user=args.user)
+        # Adding writeconf default parameters
+        #   - where to save configuration file of conserver;
+        #   - if should automatically reload the service;
+        args.out    = conserver_conf
+        writeprocs(conf, args)
+
+    # Check if should to re-write System-D service files
+    if args.writesysd:
+        _log.info('Trying to update System-D service files...')
+        genrun(outdir=args.outsysd, user=args.user)
+
+    # Daemon reloading
     _log.info('Trigger systemd reload')
     SP.check_call([systemctl,
                    '--user' if args.user else '--system',
                    'daemon-reload'], shell=False)
 
+    # procServ restarting
     if args.autostart:
+        _log.info("Starting the service: ioc@%s.service" % args.name)
         SP.check_call([systemctl,
                        '--user' if args.user else '--system',
-                       'start', 'procserv-%s.service'%args.name])
+                       'start', 'ioc@%s.service' % args.name])
     else:
-        sys.stdout.write("# systemctl start procserv-%s.service\n"%args.name)
+        sys.stdout.write("# systemctl start ioc@%s.service\n"%args.name)
 
 def delproc(conf, args):
     from .conf import getconffiles, ConfigParser
@@ -223,12 +248,29 @@ def delproc(conf, args):
                 C.write(F)
             os.rename(cfile+'.tmp', cfile)
 
+    # Check if should to re-write Conserver coniguration file
+    if args.writeconf:
+        _log.info('Trying to update Conserver configuration file...')
+        # Updating conserver config file due the previous procedures
+        conf = getconf(user=args.user)
+        # Adding writeconf default parameters
+        #   - where to save configuration file of conserver;
+        #   - if should automatically reload the service;
+        args.out    = conserver_conf
+        writeprocs(conf, args)
+
+    # Check if should to re-write System-D service files
+    if args.writesysd:
+        _log.info('Trying to update System-D service files...')
+        genrun(outdir=args.outsysd, user=args.user)
+
+    # Daemon reloading
     _log.info('Trigger systemd reload')
     SP.check_call([systemctl,
                    '--user' if args.user else '--system',
                    'daemon-reload'], shell=False)
 
-    sys.stdout.write("# systemctl stop procserv-%s.service\n"%args.name)
+    sys.stdout.write("# systemctl stop ioc@%s.service\n"%args.name)
 
 def writeprocs(conf, args):
     opts = {
@@ -257,28 +299,30 @@ console %(name)s {
 """%opts)
             else:
                 F.write("""    type uds;
-    uds %(rundir)s/procserv-%(name)s/control;
+    uds %(rundir)s/ioc@%(name)s/control;
 }
 """%opts)
 
     os.rename(args.out+'.tmp', args.out)
 
+    # Reloading conserver-server
     if args.reload:
         _log.debug('Reloading conserver-server')
         SP.check_call([systemctl,
                     '--user' if args.user else '--system',
-                    'reload', 'conserver-server.service'], shell=False)
+                    'restart', 'conserver'], shell=False)
     else:
-        sys.stdout.write('# systemctl reload conserver-server.service\n')
+        sys.stdout.write('# systemctl restart conserver\n')
 
 def getargs():
     from argparse import ArgumentParser
+
     P = ArgumentParser()
     P.add_argument('--user', action='store_true', default=os.geteuid()!=0,
                    help='Consider user config')
     P.add_argument('--system', dest='user', action='store_false',
                    help='Consider system config')
-    P.add_argument('-v','--verbose', action='count', default=0)
+    P.add_argument('-v', '--verbose', action='count', default=0)
 
     SP = P.add_subparsers()
 
@@ -289,34 +333,50 @@ def getargs():
     S.set_defaults(func=syslist)
 
     S = SP.add_parser('add', help='Create a new procServ instance')
-    S.add_argument('-C','--chdir', default=os.getcwd(), help='Run directory for instance')
-    S.add_argument('-P','--port', help='telnet port')
-    S.add_argument('-U','--user', dest='username')
-    S.add_argument('-G','--group')
-    S.add_argument('-H','--host', help='Target IOC hostname', default='localhost')
-    S.add_argument('-S','--site', help='Allow site-specific configuration')
-    S.add_argument('-f','--force', action='store_true', default=False)
-    S.add_argument('-A','--autostart',action='store_true', default=False,
-                   help='Automatically start after adding')
+    S.add_argument('-C', '--chdir', default=os.getcwd(), help='Run directory for instance')
+    S.add_argument('-P', '--port', help='telnet port')
+    S.add_argument('-U', '--user', dest='username')
+    S.add_argument('-G', '--group')
+    S.add_argument('-H', '--host', help='Target IOC hostname', default='localhost')
+    S.add_argument('-S', '--site', help='Allow site-specific configuration')
+    S.add_argument('-f', '--force', action='store_true', default=False)
+    S.add_argument('-A', '--autostart',action='store_true', default=False,
+                    help='Automatically start the service after adding it')
+    S.add_argument('-w', '--writeconf', action='store_true', default=True,
+                    help='Automatically update Conserver configuration')
+    S.add_argument('-D', '--outsysd', default=systemd_dir)
+    S.add_argument('-d', '--writesysd', action='store_true', default=True,
+                    help='Create System-D service files')
+    S.add_argument('-R', '--reload', action='store_true', default=False,
+                    help='Restart conserver-server')
     S.add_argument('--command', help='Command script or executable, without path (chdir is added later)')
     S.add_argument('name', help='Instance name')
     #S.add_argument('command', nargs='+', help='Command script or executable, without path (chdir is added later)')
     S.set_defaults(func=addproc)
 
     S = SP.add_parser('remove', help='Remove a procServ instance')
-    S.add_argument('-f','--force', action='store_true', default=False)
+    S.add_argument('-f', '--force', action='store_true', default=False)
+    S.add_argument('-w', '--writeconf', action='store_true', default=True,
+                    help='Automatically update Conserver configuration')
+    S.add_argument('-D', '--outsysd', default=systemd_dir)
+    S.add_argument('-d', '--writesysd', action='store_true', default=True,
+                    help='Create System-D service files')
+    S.add_argument('-R', '--reload', action='store_true', default=False,
+                    help='Restart conserver-server')
     S.add_argument('name', help='Instance name')
     S.set_defaults(func=delproc)
 
     S = SP.add_parser('write-procs-cf', help='Write conserver config')
-    S.add_argument('-f','--out',default='/etc/conserver/procs.cf') 
-    S.add_argument('-R','--reload', action='store_true', default=False)
+    S.add_argument('-f', '--out', default=conserver_conf)
+    S.add_argument('-R', '--reload', action='store_true', default=False,
+                    help='Restart conserver-server')
     S.set_defaults(func=writeprocs)
 
     A = P.parse_args()
     if not hasattr(A, 'func'):
         P.print_help()
         sys.exit(1)
+
     return A
 
 def main(args):

--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -9,6 +9,8 @@ import subprocess as SP
 from .conf import getconf, getrundir, getgendir
 from .generator import run as genrun
 
+from pkg_resources import resource_filename
+
 try:
     import shlex
 except ImportError:
@@ -112,7 +114,12 @@ def addproc(conf, args):
     # Try reading in the site default file
     if args.site is not None:
         try:
-            conf_path = os.path.join(os.getcwd(), 'conf')
+            # Firstly try to access a config file in the dist-packages (when installed)
+            conf_path = resource_filename(__name__, 'conf')
+            if not os.path.exists(conf_path):
+                # Whether it doesn't exist, try to access in the current directory
+                conf_path = os.path.join(os.getcwd(), 'conf')
+            # Then concatenate directory with selected site configuration file name
             conf_path = os.path.join(conf_path, args.site+'.conf')
 
             site_conf = ConfigParser()
@@ -187,8 +194,8 @@ chdir = %(chdir)s
         conf = getconf(user=args.user)
         # Adding writeconf default parameters
         #   - where to save configuration file of conserver;
-        #   - if should automatically reload the service;
-        args.out    = conserver_conf
+        #   - whether should automatically reload the service;
+        args.out = conserver_conf
         writeprocs(conf, args)
 
     # Check if should to re-write System-D service files
@@ -255,8 +262,8 @@ def delproc(conf, args):
         conf = getconf(user=args.user)
         # Adding writeconf default parameters
         #   - where to save configuration file of conserver;
-        #   - if should automatically reload the service;
-        args.out    = conserver_conf
+        #   - whether should automatically reload the service;
+        args.out = conserver_conf
         writeprocs(conf, args)
 
     # Check if should to re-write System-D service files

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,15 @@
 
 from distutils.core import setup
 
-setup(
-    name='procServUtils',
-    description='Support scripts for procServ',
-    packages = ['procServUtils'],
-    scripts = [
-        'manage-procs',
-        #'procServ-launcher',
-        #'prtelnet',
-	'systemd-procserv-generator-system',
-	'systemd-procserv-generator-user',
-    ],
+setup (
+    name            = 'procServUtils',
+    description     = 'Support scripts for procServ',
+    packages        = ['procServUtils', 'procServUtils.conf'],
+    package_dir     = {'procServUtils': 'procServUtils',
+                        'procServUtils.conf': 'conf'},
+    package_data    = {'procServUtils': ['*.py'],
+                        'procServUtils.conf': ['*.conf']},
+    scripts         = ['manage-procs',
+                        'systemd-procserv-generator-system',
+                        'systemd-procserv-generator-user'],
 )


### PR DESCRIPTION
Hello Wayne!

I'm proposing some changes here, I've performed some tests and they seem to be working fine, but, it's always good to test them more;

Main topics:
* Cleanup of the *.service files at generator;
* Support to re-write conserver and sustem-d configuration files when adding or removing an IOC automatically;
* It seems that '.service' files prefix name were changed from 'procserv-' to 'ioc@' in the generator, but not in manage scripts... I did it...