### PR TITLE
Fixing a bug when adding services which replace BASE end REQ version all the time

### DIFF
--- a/procServUtils/manage.py
+++ b/procServUtils/manage.py
@@ -8,6 +8,7 @@ import subprocess as SP
 
 from .conf import getconf, getrundir, getgendir
 from .generator import run as genrun
+from .generator import clean as genclean
 
 from pkg_resources import resource_filename
 
@@ -201,7 +202,7 @@ chdir = %(chdir)s
     # Check if should to re-write systemd service files
     if args.writesysd:
         _log.info('Trying to update systemd service files...')
-        genrun(outdir=args.outsysd, user=args.user)
+        genrun(outdir=args.outsysd, user=args.user, name=args.name)
 
     # Daemon reloading
     _log.info('Trigger systemd reload')
@@ -266,10 +267,10 @@ def delproc(conf, args):
         args.out = conserver_conf
         writeprocs(conf, args)
 
-    # Check if should to re-write systemd service files
+    # Check if should update (in this case remove) systemd service files
     if args.writesysd:
         _log.info('Trying to update systemd service files...')
-        genrun(outdir=args.outsysd, user=args.user)
+        genclean(outdir=args.outsysd, name=args.name)
 
     # Daemon reloading
     _log.info('Trigger systemd reload')


### PR DESCRIPTION
Fixing a bug related to re-write service settings and replacing EPICS (BASE and REQ) version in a wrong manner; Created a new way to clean the service settings.

I've performed tests:
* add services using different EPICS BASE and REQUIRE versions (sourcing setEnv script); previous are kept now;
* removed services; previous continue there, running; all related filed removed;